### PR TITLE
feat(meta): add Subscription::effectiveMeta() and isInTrial()

### DIFF
--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -39,10 +39,10 @@ use Spatie\EloquentSortable\Sortable;
  */
 class Subscription extends Model implements Sortable
 {
-    use SoftDeletes;
     use ConsumesFeatures;
-    use SortableMoveTo;
     use HasCountableAndUncountableFeatures;
+    use SoftDeletes;
+    use SortableMoveTo;
 
     /** @var array<string, string> */
     public array $sortable = [
@@ -113,8 +113,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeByPlanId(Builder $builder, int $planId): Builder
@@ -137,6 +136,30 @@ class Subscription extends Model implements Sortable
         $date ??= now();
 
         return $this->trial_ends_at && $date->lt($this->trial_ends_at);
+    }
+
+    /**
+     * Whether the subscription is still in its trial at the given moment.
+     *
+     * Unlike onTrial(), which checks against the current time, this defaults to
+     * the period start, so billing logic can decide whether a whole period falls
+     * into the trial.
+     */
+    public function isInTrial(?Carbon $at = null): bool
+    {
+        $at ??= $this->period_starts_at ?? now();
+
+        return $this->trial_ends_at !== null && $at->lt($this->trial_ends_at);
+    }
+
+    /**
+     * Resolve a meta value, letting the subscription's own meta override the
+     * plan's meta. Returns the given default when neither defines the key.
+     */
+    public function effectiveMeta(string $key, mixed $default = null): mixed
+    {
+        return data_get($this->meta, $key)
+            ?? data_get($this->plan->meta, $key, $default);
     }
 
     public function canceled(?Carbon $date = null): bool
@@ -200,8 +223,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeEndingTrial(Builder $builder, int $dayRange = 3): Builder
@@ -210,8 +232,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeEndedTrial(Builder $builder): Builder
@@ -220,8 +241,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeEnding(Builder $builder, int $dayRange = 3): Builder
@@ -230,8 +250,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeEnded(Builder $builder): Builder
@@ -240,8 +259,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeActive(Builder $builder): Builder
@@ -250,8 +268,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeUncanceled(Builder $builder): Builder
@@ -260,8 +277,7 @@ class Subscription extends Model implements Sortable
     }
 
     /**
-     * @param Builder<Subscription> $builder
-     *
+     * @param  Builder<Subscription>  $builder
      * @return Builder<Subscription>
      */
     public function scopeCanceled(Builder $builder): Builder

--- a/tests/Unit/EffectiveMetaTest.php
+++ b/tests/Unit/EffectiveMetaTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Lacodix\LaravelPlans\Models\Plan;
-use Tests\Models\User;
-
 use function Spatie\PestPluginTestTime\testTime;
+
+use Tests\Models\User;
 
 beforeEach(function () {
     $this->user = User::factory()->create();

--- a/tests/Unit/EffectiveMetaTest.php
+++ b/tests/Unit/EffectiveMetaTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Lacodix\LaravelPlans\Models\Plan;
+use Tests\Models\User;
+
+use function Spatie\PestPluginTestTime\testTime;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    config()->set('plans.sync_subscriptions', false);
+});
+
+$plainPlan = fn (array $meta) => Plan::factory([
+    'billing_period' => 1,
+    'billing_interval' => 'month',
+    'trial_period' => 0,
+    'grace_period' => 0,
+    'meta' => $meta,
+])->create();
+
+it('falls back to the plan meta when the subscription has no override', function () use ($plainPlan) {
+    $sub = $this->user->subscribe($plainPlan(['price_per_member' => 0.05]));
+
+    expect($sub->effectiveMeta('price_per_member'))->toBe(0.05);
+});
+
+it('lets the subscription meta override the plan meta', function () use ($plainPlan) {
+    $sub = $this->user->subscribe($plainPlan(['price_per_member' => 0.05]), meta: ['price_per_member' => 0.03]);
+
+    expect($sub->effectiveMeta('price_per_member'))->toBe(0.03);
+});
+
+it('returns the default when neither plan nor subscription define the key', function () use ($plainPlan) {
+    $sub = $this->user->subscribe($plainPlan([]));
+
+    expect($sub->effectiveMeta('missing', 42))->toBe(42);
+});
+
+test('isInTrial checks against the period start by default', function () {
+    testTime()->freeze('2020-01-01 12:00:00');
+
+    $plan = Plan::factory([
+        'billing_period' => 1,
+        'billing_interval' => 'month',
+        'trial_period' => 1,
+        'trial_interval' => 'month',
+        'grace_period' => 0,
+    ])->create();
+
+    $sub = $this->user->subscribe($plan);
+
+    // Period starts 2020-01-01, trial ends 2020-01-31 -> still in trial at start.
+    expect($sub->isInTrial())->toBeTrue();
+
+    // A moment after the trial ends is no longer in trial.
+    expect($sub->isInTrial(now()->parse('2020-02-15')))->toBeFalse();
+});
+
+test('isInTrial is false without a trial', function () {
+    $plan = Plan::factory([
+        'billing_period' => 1,
+        'billing_interval' => 'month',
+        'trial_period' => 0,
+        'grace_period' => 0,
+    ])->create();
+
+    $sub = $this->user->subscribe($plan);
+
+    expect($sub->isInTrial())->toBeFalse();
+});


### PR DESCRIPTION
effectiveMeta() resolves a meta key with subscription meta overriding plan meta. isInTrial() checks the trial against the period start (default) so billing can decide whether a whole period falls into the trial.